### PR TITLE
pre-commit hooks should not set verbose: true

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -17,7 +17,6 @@
   exclude: \.terraform\/.*$
   always_run: false
   pass_filenames: false
-  verbose: true
   additional_dependencies: ['checkov']
 
 - id: tf2docs
@@ -30,4 +29,3 @@
   exclude: \.terraform\/.*$
   always_run: false
   pass_filenames: false
-  verbose: true


### PR DESCRIPTION
this is a debugging flag, I'm temporarily removing this from pre-commit.com for now, please fix this and revert this change:  https://github.com/pre-commit/pre-commit.com/commit/7a887a568b8644bcd230b4b09e54a9f91e914bf8